### PR TITLE
fix: not verifyng signature correctly in the case of message digest with leading zeros

### DIFF
--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -82,8 +82,9 @@ EC.prototype.genKeyPair = function genKeyPair(options) {
   } while (true);
 };
 
-EC.prototype._truncateToN = function truncateToN(msg, truncOnly) {
-  var delta = msg.byteLength() * 8 - this.n.bitLength();
+EC.prototype._truncateToN = function truncateToN(msg, truncOnly, bitSize) {
+  bitSize = bitSize || msg.byteLength() * 8;
+  var delta = bitSize - this.n.bitLength();
   if (delta > 0)
     msg = msg.ushrn(delta);
   if (!truncOnly && msg.cmp(this.n) >= 0)
@@ -91,6 +92,21 @@ EC.prototype._truncateToN = function truncateToN(msg, truncOnly) {
   else
     return msg;
 };
+
+EC.prototype.truncateMsg  = function truncateMSG(msg) {
+  //bit size is determined correctly only in the case of Uint8Array and hex strings
+  var bitSize;
+  if (msg instanceof Uint8Array) {
+    bitSize = msg.byteLength * 8;
+    msg = this._truncateToN(new BN(msg, 16), false, bitSize);
+  } else if (typeof msg === 'string') {
+    bitSize = msg.length * 4;
+    msg = this._truncateToN(new BN(msg, 16), false, bitSize);
+  } else {
+    msg = this._truncateToN(new BN(msg, 16));
+  }
+  return msg;
+}
 
 EC.prototype.sign = function sign(msg, key, enc, options) {
   if (typeof enc === 'object') {
@@ -101,8 +117,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
     options = {};
 
   key = this.keyFromPrivate(key, enc);
-  msg = this._truncateToN(new BN(msg, 16));
-
+  msg = this.truncateMsg(msg);
   // Zero-extend key to provide enough entropy
   var bytes = this.n.byteLength();
   var bkey = key.getPrivate().toArray('be', bytes);
@@ -158,7 +173,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
 };
 
 EC.prototype.verify = function verify(msg, signature, key, enc) {
-  msg = this._truncateToN(new BN(msg, 16));
+  msg = this.truncateMsg(msg);
   key = this.keyFromPublic(key, enc);
   signature = new Signature(signature, 'hex');
 

--- a/lib/elliptic/ec/index.js
+++ b/lib/elliptic/ec/index.js
@@ -94,7 +94,7 @@ EC.prototype._truncateToN = function truncateToN(msg, truncOnly, bitSize) {
 };
 
 EC.prototype.truncateMsg  = function truncateMSG(msg) {
-  //bit size is determined correctly only in the case of Uint8Array and hex strings
+  // Bit size is only determined correctly for Uint8Arrays and hex strings
   var bitSize;
   if (msg instanceof Uint8Array) {
     bitSize = msg.byteLength * 8;
@@ -118,6 +118,7 @@ EC.prototype.sign = function sign(msg, key, enc, options) {
 
   key = this.keyFromPrivate(key, enc);
   msg = this.truncateMsg(msg);
+
   // Zero-extend key to provide enough entropy
   var bytes = this.n.byteLength();
   var bkey = key.getPrivate().toArray('be', bytes);

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -128,6 +128,36 @@ describe('ECDSA', function() {
   test('p384');
   test('p521');
 
+  describe('test for signatures with leading zero in the hash', function() {
+      it('should sign and verify signature', function() {
+        var dgst = '00fc35f7372aa8562b8ce64b93197a0970a513d3b666974f37c1120e9654a56e136baf07a16279a83f6841c376851f356a679664e102f4717e4a10b18e914121';
+        var key = '1e20f5e048a5886f1f157c74e91bde2b98c8b52d58e5003d57053fc4b0bd6' +
+        '5d6f15eb5d1ee1610df870795143627d042';
+        var public = {
+          x: '68b665dd91c195800650cdd363c625f4e742e8134667b767b1b47679358' +
+          '8f885ab698c852d4a6e77a252d6380fcaf068',
+          y: '55bc91a39c9ec01dee36017b7d673a931236d2f1f5c83942d049e3fa206' +
+          '07493e0d038ff2fd30c2ab67d15c85f7faa59'
+        };
+        var ecdsa = new elliptic.ec('brainpoolP384r1');
+        var sign = ecdsa.sign(dgst, key);
+        assert.ok(ecdsa.verify(dgst, sign, public));
+      });
+      it('should verify node crypto signature with leading zero in the hash', function() {
+        var dgst = '00fc35f7372aa8562b8ce64b93197a0970a513d3b666974f37c1120e9654a56e136baf07a16279a83f6841c376851f356a679664e102f4717e4a10b18e914121';
+        var public = '04862ffae892e8d6f321a72b5bd5b62f06177f68a1dd7b667091eeebcd615360165097f0d4ae932b5408644219391b792a1567fdf0efc3a6f56663a103af722398e0d6a3036f19f0b802f73dad846057c19b3015152c84becad4b560da40296e2f';
+        var sig = {
+          r: '3fa687a62f94edf3a7e4d0310fe9c0cdadcb5054ab2a83eff3693b342945ffe1c5974f1b3779a2b375f5e61e3463e3a0',
+          s: '5c012ed923577f929f1e36756167d19c63c478e004f4045277c7f7d02437a1d154c48cf125b007e3d1b7594539b16e87'
+        }
+        var ecdsa = new elliptic.ec('brainpoolP384r1');
+        var publicKey = ecdsa.keyFromPublic(public, 'hex');
+        assert.ok(publicKey.validate().result,
+        'Invalid public key');
+        assert.ok(publicKey.verify(dgst, sig));
+      });
+  });
+
   describe('RFC6979 vector', function() {
     function test(opt) {
       opt.cases.forEach(function(c) {


### PR DESCRIPTION
This commit should solve https://github.com/openpgpjs/openpgpjs/issues/854